### PR TITLE
Check if statistics exist when deleting

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -113,7 +113,8 @@ def remove_statistic():
       db.session.delete(host)
 
     statistic = Statistic.query.get(payload['statistic_key'])
-    db.session.delete(statistic)
+    if statistic:
+        db.session.delete(statistic)
 
     db.session.commit()
     db.session.flush()


### PR DESCRIPTION
Currently, the delete statistic route throws an error if the passed statistic doesn't exist. 

Opencast always calls this route regardless of whether statistics are available or allowed. If an error occurs here, Opencast will abort the delete process.